### PR TITLE
update sequence_generator.py to work for new keras version

### DIFF
--- a/gen_utils/sequence_generator.py
+++ b/gen_utils/sequence_generator.py
@@ -10,7 +10,7 @@ def generate_from_seed(model, seed, sequence_length, data_variance, data_mean):
 	#Step 2 - Concatenate X_n + 1 onto A
 	#Step 3 - Repeat MAX_SEQ_LEN times
 	for it in xrange(sequence_length):
-		seedSeqNew = model._predict(seedSeq) #Step 1. Generate X_n + 1
+		seedSeqNew = model.predict(seedSeq) #Step 1. Generate X_n + 1
 		#Step 2. Append it to the sequence
 		if it == 0:
 			for i in xrange(seedSeqNew.shape[1]):


### PR DESCRIPTION
the newest version of keras uses Sequence.predict() instead of Sequence._predict()

thanks to @dlahoti and others (who made identical changes) for this patch
